### PR TITLE
docs: update sample snippet for nestjs v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import { Module } from '@nestjs/common';
 
 @Module({
   controllers: [AuthController],
-  providers: [AuthService, AdminGuard, UserMiddleware, AdminService],
+  providers: [AuthService, AdminService],
   imports: [TypeOrmModule.forFeature([Admin])],
   exports: [AuthService],
 })


### PR DESCRIPTION
Middlewares and non-global guards aren't supposed to be listed in the `providers` array. Although that code works fine, it's does nothing (ie., the middleware and the guard aren't applied)

Is there any reason why did you have them in that code snippet? :thinking: I might be missing something
